### PR TITLE
LAT/LON format fix

### DIFF
--- a/src/main/java/org/marsik/ham/grid/CoordinateWriter.java
+++ b/src/main/java/org/marsik/ham/grid/CoordinateWriter.java
@@ -1,11 +1,11 @@
 package org.marsik.ham.grid;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class CoordinateWriter {
-    private static final Pattern LAT_RE = Pattern.compile("([NS]) ?([0-9]{0,2}) +([0-9]{1,2}(\\.[0-9]+)?)", Pattern.CASE_INSENSITIVE);
-    private static final Pattern LON_RE = Pattern.compile("([EW]) ?([01]?[0-9]{0,2}) +([0-9]{1,2}(\\.[0-9]+)?)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern LAT_LON_RE = Pattern.compile("([NSWE])([01][0-9]{2}) ([0-9]{2}(\\.[0-9]{3}))", Pattern.CASE_INSENSITIVE);
 
     private static String getLatitudePrefix(Double lat) {
         return lat >= 0.0 ? "N" : "S";
@@ -21,7 +21,7 @@ public class CoordinateWriter {
         int deg = (int) lon;
         double min = 60.0 * (lon - (int)lon);
 
-        return String.format("%s%03d %02.3f", prefix, deg, min);
+        return latLonDmFormat(prefix, deg, min);
     }
 
     public static String latToDM(double lat) {
@@ -30,11 +30,11 @@ public class CoordinateWriter {
         int deg = (int) lat;
         double min = 60.0 * (lat - (int)lat);
 
-        return String.format("%s%02d %02.3f", prefix, deg, min);
+        return latLonDmFormat(prefix, deg, min);
     }
 
     public static double dmToLat(String string) {
-        Matcher matcher = LAT_RE.matcher(string);
+        Matcher matcher = LAT_LON_RE.matcher(string);
         if (matcher.matches()) {
             String prefix = matcher.group(1);
             int deg = Integer.parseInt(matcher.group(2));
@@ -46,7 +46,7 @@ public class CoordinateWriter {
     }
 
     public static double dmToLon(String string) {
-        Matcher matcher = LON_RE.matcher(string);
+        Matcher matcher = LAT_LON_RE.matcher(string);
         if (matcher.matches()) {
             String prefix = matcher.group(1);
             int deg = Integer.parseInt(matcher.group(2));
@@ -55,5 +55,9 @@ public class CoordinateWriter {
         } else {
             throw new IllegalArgumentException("Bad longitude format");
         }
+    }
+
+    private static String latLonDmFormat(String prefix, int deg, double min) {
+        return String.format(Locale.US, "%s%03d %02.3f", prefix, deg, min);
     }
 }

--- a/src/test/java/org/marsik/ham/grid/CoordinateWriterTest.java
+++ b/src/test/java/org/marsik/ham/grid/CoordinateWriterTest.java
@@ -1,33 +1,34 @@
 package org.marsik.ham.grid;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CoordinateWriterTest {
     @Test
-    public void testNorthLatitude() throws Exception {
+    public void testNorthLatitude() {
         assertThat(CoordinateWriter.latToDM(50.5))
                 .isNotNull()
-                .isEqualTo("N50 30.000");
+                .isEqualTo("N050 30.000");
     }
 
     @Test
-    public void testEastLongitude() throws Exception {
+    public void testEastLongitude() {
         assertThat(CoordinateWriter.lonToDM(15.2))
                 .isNotNull()
                 .isEqualTo("E015 12.000");
     }
 
     @Test
-    public void testParsingNorthLatitude() throws Exception {
-        assertThat(CoordinateWriter.dmToLat("N50 30.000"))
+    public void testParsingNorthLatitude() {
+        assertThat(CoordinateWriter.dmToLat("N050 30.000"))
                 .isEqualTo(50.5);
     }
 
     @Test
-    public void testParsingEastLongitude() throws Exception {
+    public void testParsingEastLongitude() {
         assertThat(CoordinateWriter.dmToLon("E015 30.000"))
                 .isEqualTo(15.5);
     }
+
 }


### PR DESCRIPTION
According specification:
https://www.adif.org/310/ADIF_310.htm#Location

Location is a sequence of 11 characters representing a latitude or longitude in X**D**DD MM.MMM format, where

    X is a directional Character from the set {E, W, N, S}
    **DDD is a 3-Digit degrees specifier, where 0 <= DDD <= 180 [use leading zeroes]**
    There is a single space character in between DDD and MM.MMM
    MM.MMM is an unsigned Number minutes specifier with its decimal point in the third position, where 00.000 <= MM.MMM <= 59.999  [use leading and trailing zeroes]