### PR TITLE
AdiWriter - Fix for decimal formatting type, which should always cont…

### DIFF
--- a/src/main/java/org/marsik/ham/adif/AdiWriter.java
+++ b/src/main/java/org/marsik/ham/adif/AdiWriter.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 import org.marsik.ham.adif.enums.AdifEnumCode;
@@ -82,7 +83,7 @@ public class AdiWriter {
     }
 
     private String encode(Double value) {
-        return String.format("%f", value);
+        return String.format(Locale.US, "%f", value);
     }
 
     private String encode(AdifEnumCode value) {

--- a/src/test/java/org/marsik/ham/adif/AdiWriterWithLocalesTest.java
+++ b/src/test/java/org/marsik/ham/adif/AdiWriterWithLocalesTest.java
@@ -1,0 +1,58 @@
+package org.marsik.ham.adif;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class AdiWriterWithLocalesTest {
+
+    private Locale originalLocale;
+    private final Locale testLocale;
+    private final String expected;
+
+    @Before
+    public void setUp() {
+        originalLocale = Locale.getDefault();
+    }
+
+    @After
+    public void tearDown() {
+        Locale.setDefault(originalLocale);
+    }
+
+    public AdiWriterWithLocalesTest(Locale testLocale, String expected) {
+        this.testLocale = testLocale;
+        this.expected = expected;
+    }
+
+    @Parameterized.Parameters
+    public static List<Object[]> data() {
+        String expectedDouble = "<DOUBLE:8>3.700000";
+
+        return Arrays.asList(new Object[][]{
+                {Locale.US, expectedDouble},
+                {new Locale("pl", "PL"), expectedDouble}
+        });
+    }
+
+    @Test
+    public void testDoubleInDifferentLocales()  {
+        Locale.setDefault(testLocale);
+
+        AdiWriter writer = new AdiWriter();
+        writer.append("double", 3.7d);
+
+        assertThat(writer.toString())
+                .isEqualTo(expected);
+    }
+
+}


### PR DESCRIPTION
AdiWriter - Fix for decimal formatting type, which should always contain a dot regardless of the locale.

http://www.adif.org/310/ADIF_310.htm#Number

"a sequence of one or more Digits representing a decimal number, optionally preceded by a minus sign (ASCII code 45) and optionally including a single decimal point  (ASCII  code 46)"